### PR TITLE
Enhance performance and a11y

### DIFF
--- a/components/KurdCard.tsx
+++ b/components/KurdCard.tsx
@@ -27,19 +27,11 @@ export default function KurdCard({ kurd }: { kurd: KurdWithTopics }) {
               alt={kurd.name}
               layout="fill"
               objectFit="fill"
-              height={250}
-              width={250}
             />
           </div>
         }
         actions={[
-          <a
-            key="social"
-            tabIndex={-1}
-            target="_blank"
-            href={kurd.link}
-            rel="noreferrer"
-          >
+          <>
             {kurd.link.includes("twitter") ? (
               <TwitterOutlined key="twitter" />
             ) : kurd.link.includes("behance") ? (
@@ -53,7 +45,7 @@ export default function KurdCard({ kurd }: { kurd: KurdWithTopics }) {
             ) : (
               <LinkOutlined key="link" />
             )}
-          </a>,
+          </>,
         ]}
       >
         <Meta title={kurd.name} />

--- a/components/KurdCard.tsx
+++ b/components/KurdCard.tsx
@@ -27,7 +27,13 @@ export default function KurdCard({ kurd }: { kurd: KurdWithTopics }) {
           />
         }
         actions={[
-          <a key="social" target="_blank" href={kurd.link} rel="noreferrer">
+          <a
+            key="social"
+            tabIndex={-1}
+            target="_blank"
+            href={kurd.link}
+            rel="noreferrer"
+          >
             {kurd.link.includes("twitter") ? (
               <TwitterOutlined key="twitter" />
             ) : kurd.link.includes("behance") ? (

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+/**
+ * @type import("next").NextConfig
+ */
 module.exports = {
-  reactStrictMode: true
-}
+  reactStrictMode: true,
+  swcMinify: true,
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 // react & next
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Head from "next/head";
 import BubbleUI from "react-bubble-ui";
 import "react-bubble-ui/dist/index.css";
@@ -9,6 +9,7 @@ import KurdCard from "../components/KurdCard";
 
 // antd
 import { Button } from "antd";
+import type { Input } from "antd";
 
 // styles
 import styles from "../styles/Home.module.css";
@@ -17,28 +18,44 @@ import Search from "antd/lib/input/Search";
 import Dropdown from "../components/Dropdown";
 import { Avatar } from "antd";
 
-//
 import { AwesomeKurds } from "../kurds";
 import { getPhoto } from "../utilities";
+
+const BUBBLE_UI_OPTIONS = {
+  size: 200,
+  minSize: 25,
+  gutter: 20,
+  provideProps: true,
+  numCols: 8,
+  fringeWidth: 200,
+  yRadius: 130,
+  xRadius: 220,
+  cornerRadius: 50,
+  showGuides: false,
+  compact: false,
+  gravitation: 5,
+};
 
 export default function Home() {
   const [awesomeKurds, setAwesomeKurds] = useState<AwesomeKurds>();
   const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
   const [activeTag, setActiveTag] = useState("");
-  const options = {
-    size: 200,
-    minSize: 25,
-    gutter: 8,
-    provideProps: true,
-    numCols: 8,
-    fringeWidth: 200,
-    yRadius: 130,
-    xRadius: 220,
-    cornerRadius: 50,
-    showGuides: false,
-    compact: false,
-    gravitation: 5,
-  };
+  const searchInputRef = useRef<Input | null>(null);
+  const shuffledAwesomeKurds = useMemo(
+    () => (awesomeKurds?.kurds.length > 0 ? _.shuffle(awesomeKurds.kurds) : []),
+    [awesomeKurds?.kurds]
+  );
+
+  const filteredAwesomeKurds = useMemo(
+    () =>
+      awesomeKurds
+        ?.searchForKurd(debouncedSearchTerm)
+        .filter((k) =>
+          activeTag && activeTag != "All" ? k.tags.includes(activeTag) : true
+        ),
+    [activeTag, awesomeKurds, debouncedSearchTerm]
+  );
 
   useEffect(() => {
     (async () => {
@@ -51,6 +68,31 @@ export default function Home() {
       setAwesomeKurds(new AwesomeKurds(readme));
     })();
   }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "/" && searchInputRef.current) {
+        searchInputRef.current.focus();
+      }
+    };
+
+    document.addEventListener("keyup", handler);
+
+    return () => {
+      document.removeEventListener("keyup", handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    const timeoutHandle = setTimeout(
+      () => setDebouncedSearchTerm(searchTerm),
+      200
+    );
+
+    return () => {
+      clearTimeout(timeoutHandle);
+    };
+  }, [searchTerm]);
 
   if (typeof awesomeKurds === "undefined") {
     return <Loading />;
@@ -72,9 +114,11 @@ export default function Home() {
           Meet {awesomeKurds.kurds.length} awesome Kurds.
         </p>
         <div className={styles.CTA}>
-          <BubbleUI options={options} className="myBubbleUI">
-            {_.shuffle(awesomeKurds.kurds).map((k, i) => {
-              return <Avatar key={`dev-${i}`} src={getPhoto(k)} className="child" />;
+          <BubbleUI options={BUBBLE_UI_OPTIONS} className="myBubbleUI">
+            {shuffledAwesomeKurds.map((k, i) => {
+              return (
+                <Avatar key={`dev-${i}`} src={getPhoto(k)} className="child" />
+              );
             })}
           </BubbleUI>
           <a
@@ -96,34 +140,34 @@ export default function Home() {
         <div className={styles.search}>
           <Dropdown setActiveTag={setActiveTag} tags={awesomeKurds.tags} />
           <Search
+            ref={searchInputRef}
             placeholder="Search..."
             allowClear
             enterButton="Search"
             size="large"
-            onSearch={(e) => setSearchTerm(e)}
+            onSearch={(value) => setSearchTerm(value)}
             onChange={(e) => setSearchTerm(e.target.value)}
+            suffix={
+              <kbd>
+                <span className="keyboard-child">CTRL</span>
+                <span className="keyboard-child">/</span>
+              </kbd>
+            }
           />
         </div>
         <div className={styles.dealer}>
-          {awesomeKurds
-            .searchForKurd(searchTerm)
-            .filter((k) =>
-              activeTag && activeTag != "All"
-                ? k.tags.includes(activeTag)
-                : true
-            )
-            .map((k, i) => (
-              <KurdCard key={i} kurd={k} />
-            ))}
+          {filteredAwesomeKurds.map((k, i) => (
+            <KurdCard key={i} kurd={k} />
+          ))}
         </div>
       </main>
 
       <footer className={styles.footer}>
-        Powered by{" "}
+        <span>Powered by</span>
         <a href="https://devs.krd" target="_blank" rel="noreferrer">
           devs.krd
         </a>
-        .
+        <span>.</span>
       </footer>
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -54,7 +54,7 @@ export default function Home({ readme }: Props) {
     () =>
       awesomeKurds
         ?.searchForKurd(debouncedSearchTerm)
-        .filter((k) =>
+        .filter(k =>
           activeTag && activeTag != "All" ? k.tags.includes(activeTag) : true
         ),
     [activeTag, awesomeKurds, debouncedSearchTerm]
@@ -63,13 +63,6 @@ export default function Home({ readme }: Props) {
   useEffect(() => {
     setAwesomeKurds(new AwesomeKurds(readme));
   }, [readme]);
-
-  // useEffect(() => {
-  //   if (awesomeKurds) {
-  //     const shuffledAwesomeKurds = _.shuffle(awesomeKurds?.kurds);
-  //     // setShuffledAwesomeKurds(shuffledAwesomeKurds);
-  //   }
-  // }, [awesomeKurds]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -170,8 +163,8 @@ export default function Home({ readme }: Props) {
             allowClear
             enterButton="Search"
             size="large"
-            onSearch={(value) => setSearchTerm(value)}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onSearch={value => setSearchTerm(value)}
+            onChange={e => setSearchTerm(e.target.value)}
             suffix={
               <kbd>
                 <span className="keyboard-child">CTRL</span>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -60,16 +60,17 @@
   margin: 1rem;
 }
 
-.card:hover {
+.card:hover,
+a:focus > .card {
   cursor: pointer;
   box-shadow: -21px 28px 105px -32px rgba(0, 0, 0, 0.2);
   -webkit-box-shadow: -21px 28px 105px -32px rgba(0, 0, 0, 0.2);
   -moz-box-shadow: -21px 28px 105px -32px rgba(0, 0, 0, 0.2);
-  transition: 0.3s;
+  transition: 0.3s ease-in-out;
 }
 
 .avatar {
-  min-width: 15rem;
+  min-width: 18rem;
   aspect-ratio: 1;
 }
 
@@ -97,6 +98,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  gap: 4px;
 }
 
 .footer a {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,3 +28,21 @@ body{
 	height: 100%;
 	border-radius: 50%;
 }
+
+.ant-input-suffix > kbd{
+  display: flex;
+  gap: 4px;
+}
+
+.keyboard-child{
+  font-family: monospace;
+  font-size: 14px;
+  background-color: #1890ff44;
+  text-align: center;
+  padding-inline: 6px;
+  border-radius: 6px;
+}
+
+.ant-input-suffix > .ant-input-clear-icon{
+  display: none;
+}


### PR DESCRIPTION
1. add: add swcMinify option in next config
  When `swcMinify` set to `true`, next v12 will use swc compiler
  written in rust and makes development much easier
  especially helps with better HMR (fast refresh).
  Read more here: https://nextjs.org/blog/next-12

2. enhance: a11y and search performance
  - KurdCard has two links in the same card one as a parent and one
    child pointing to the same link, users with screen reader and keyboard
    will get confused by when they navigate the page, so the child is now
    out of keyboard focus (using `tabIndex={-1}`).
  - Bubble options opbject moved outside of the Home component.
    Constants that aren't derivable from state/prop and doesn't change
    in the lifetime of the component shouldn't be in the component itself
  - added `debouncedSearchTerm` state which gets updated after a delay
    after the input changed to let the browser update the input as it's
    more urgent to the user, and use delayed search term to update the
    list of the cards to make the UI less janky.
  - Put the shuffled AwesomeKurds into a useMemo to not rerender
    as the user types or any other activities that make the component
    rerenders.
  - Put the AwesomeKurds into a useMemo that will update only when
    `activeTag`, `awesomeKurds` data or `debouncedSearchTerm` changes
    which are only meaningful changes the filtered list should change
    accordingly.
  - Added keyboard shortcut `CTRL` + `/` to focus the search input without
    the need to scroll up or down. Also added the suffix to show the
    keyboard keys can be used to focus the search input.
  - Updated the minimum avatar width to `18rem` to have less cards
    in one row depending on the zoom level.
  