### PR TITLE
fix: possibility of long-staled data

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 // react & next
 import { useEffect, useMemo, useRef, useState } from "react";
 import Head from "next/head";
+import type { GetStaticProps } from "next";
 import BubbleUI from "react-bubble-ui";
 import "react-bubble-ui/dist/index.css";
 import _ from "lodash";
@@ -191,18 +192,24 @@ export default function Home({ readme }: Props) {
   );
 }
 
-export const getStaticProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const res = await fetch(
     "https://raw.githubusercontent.com/DevelopersTree/awesome-kurds/main/README.md"
   );
   const readme = await res.text();
 
+  const revalidate = 60 * 60 * 24; // 24h in seconds
+
   if (!readme) {
     return {
       notFound: true,
+      // if not found, update every hour
+      revalidate: revalidate / 24,
     };
   }
+
   return {
     props: { readme },
+    revalidate,
   };
 };


### PR DESCRIPTION
This is interesting because `getStaticProps` function will be called
once in the build time, which means if there is no new deployment for
a week and during that week some change happened to the data, it
wont be shown in the website until next build happens. Which is
unfortunate because you never know when people get some free time to
make some updates on the website or maybe there is no need to change.
Usually the data fetching strategy must consider the duration for
which the data fresh/valid for the user to see.

One Solution could be use `getServerSideProps` but it may make the
TTFB long and ruin the UX. Another option is to use `revalidate`
option which is part of the return and is `false` by default, can
be set to number of seconds to re-validate (hence rebuild) the page
every time the number of seconds passed after last build which should
make sure the data is semi-fresh when a user visits the page.

See [Next.js docs](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)