### PR TITLE
Fix: Break long words to new line in order to prevent them from overflowing the card

### DIFF
--- a/styles/_card.sass
+++ b/styles/_card.sass
@@ -79,5 +79,6 @@
             border-radius: 40px
 
     h1, p, div // the name, the topics and the tags
+        word-break: break-word
         margin-left: 5px
         margin-right: 5px


### PR DESCRIPTION
This style added to name, the topics and the tags from cards.