### PR TITLE
Force card images to have square ratio

### DIFF
--- a/styles/_card.sass
+++ b/styles/_card.sass
@@ -57,6 +57,8 @@
         width: 100%
         border-radius: 10px
         margin-bottom: 0.5rem
+        aspect-ratio: 1
+        object-fit: cover
 
     h1 // the name
         font-size: 2rem


### PR DESCRIPTION
The issue had happened to a card which it's image taken from Twitter profile.