### PR TITLE
Fix: Prevented avatar images from affecting card sizes.

### DIFF
--- a/styles/_card.sass
+++ b/styles/_card.sass
@@ -5,8 +5,7 @@
         max-width: 500px
 
 .card, .search input, .search select
-    max-width: 300px
-    flex-grow: 1
+    width: 300px
 
 .search
     display: flex


### PR DESCRIPTION
**Problem:**
Cards were designed with a maximum width of 300px, but their actual width was influenced by the content inside, particularly the avatar images. If a user's avatar image was narrower than 300px, the card would shrink accordingly. This inconsistent sizing led to rows with varying widths and card counts, creating a visually unappealing layout.

**Solution:**
To ensure consistent card sizes, I've set a fixed width of 300px for all cards. This ensures uniformity across different screen sizes. Additionally, I removed the flex-grow property, which was causing unwanted variation in card sizes.

**Preview:**
![image](https://github.com/user-attachments/assets/1495030b-c3d1-45d2-b8b7-f756f0fedfc4)
